### PR TITLE
Fixes issues 1,2 & 3 in #9

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -50,13 +50,13 @@ if steam is not None and 'steamAPI' in config:
 if 'apiTimeout' in config:
 	wikitools.api.setDefaultTimeout(config['apiTimeout'])
 
-#Create dict and apply values that don't need refreshing
+# Create dict and apply values that don't need refreshing
 config['runtime'] = {
 	'rcid' : -1,
 	'onlinercid' : -1,
 	'regexes': {}
 }
-#Define values that wil be refreshed later
+# Define values that wil be refreshed later
 def setInitConf():
 	global config
 	config['runtime'].update({
@@ -64,7 +64,7 @@ def setInitConf():
 		'edits': 0,
 		'pages': {}
 	})
-setInitConf() #Append them on initial run
+setInitConf() # Append them on initial run
 
 def u(s):
 	if type(s) is type(u''):
@@ -1406,7 +1406,7 @@ def programExists(programName):
 
 def run():
 	global config
-	setInitConf() #Re-establish initial config values for additional runs
+	setInitConf() # Re-establish initial config values for additional runs
 	tprint('Bot started.')
 	loadPage(config['pages']['filters'])
 	for p in sys.argv[1:]:

--- a/bot.py
+++ b/bot.py
@@ -49,15 +49,16 @@ if steam is not None and 'steamAPI' in config:
 	steam.api.key.set(config['steamAPI'])
 if 'apiTimeout' in config:
 	wikitools.api.setDefaultTimeout(config['apiTimeout'])
-config['runtime'] = {
-	'rcid': -1,
-	'onlinercid': -1,
-	'wiki': None,
-	'edits': 0,
-	'regexes': {},
-	'pages': {}
-}
-
+def setInitConf():
+	global config
+	config['runtime'] = {
+		'rcid': -1,
+		'onlinercid': -1,
+		'wiki': None,
+		'edits': 0,
+		'regexes': {},
+		'pages': {}
+	}
 def u(s):
 	if type(s) is type(u''):
 		return s
@@ -1395,6 +1396,7 @@ def programExists(programName):
 		return result == 0
 	except:
 		return False
+
 def run():
 	global config
 	tprint('Bot started.')

--- a/bot.py
+++ b/bot.py
@@ -49,17 +49,23 @@ if steam is not None and 'steamAPI' in config:
 	steam.api.key.set(config['steamAPI'])
 if 'apiTimeout' in config:
 	wikitools.api.setDefaultTimeout(config['apiTimeout'])
+
+#Define config values that need refreshing on runIndef
 def setInitConf():
 	global config
 	config['runtime'] = {
-		'rcid': -1,
-		'onlinercid': -1,
 		'wiki': None,
 		'edits': 0,
-		'regexes': {},
 		'pages': {}
 	}
-setInitConf()
+setInitConf() #Apply them
+#Apply the remaining values that don't need refreshing
+config['runtime'] = {
+	'rcid' : -1,
+	'onlinercid' : -1,
+	'regexes': {}
+}
+
 def u(s):
 	if type(s) is type(u''):
 		return s
@@ -1400,7 +1406,7 @@ def programExists(programName):
 
 def run():
 	global config
-	setInitConf()
+	setInitConf() #Re-establish initial config values for additional runs
 	tprint('Bot started.')
 	loadPage(config['pages']['filters'])
 	for p in sys.argv[1:]:

--- a/bot.py
+++ b/bot.py
@@ -50,21 +50,21 @@ if steam is not None and 'steamAPI' in config:
 if 'apiTimeout' in config:
 	wikitools.api.setDefaultTimeout(config['apiTimeout'])
 
-#Define config values that need refreshing on runIndef
-def setInitConf():
-	global config
-	config['runtime'] = {
-		'wiki': None,
-		'edits': 0,
-		'pages': {}
-	}
-setInitConf() #Apply them
-#Apply the remaining values that don't need refreshing
+#Create dict and apply values that don't need refreshing
 config['runtime'] = {
 	'rcid' : -1,
 	'onlinercid' : -1,
 	'regexes': {}
 }
+#Define values that wil be refreshed later
+def setInitConf():
+	global config
+	config['runtime'].update({
+		'wiki': None,
+		'edits': 0,
+		'pages': {}
+	})
+setInitConf() #Append them on initial run
 
 def u(s):
 	if type(s) is type(u''):

--- a/bot.py
+++ b/bot.py
@@ -59,6 +59,7 @@ def setInitConf():
 		'regexes': {},
 		'pages': {}
 	}
+setInitConf()
 def u(s):
 	if type(s) is type(u''):
 		return s
@@ -1399,6 +1400,7 @@ def programExists(programName):
 
 def run():
 	global config
+	setInitConf()
 	tprint('Bot started.')
 	loadPage(config['pages']['filters'])
 	for p in sys.argv[1:]:


### PR DESCRIPTION
Reworks config values such that non-refreshing config values are declared on initial run, and refreshing values are appended on initial run and then reset on subsequent runs by <code>run()</code>.
